### PR TITLE
Prepare recrawler service for integration with API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ requests-futures = "*"
 [dev-packages]
 pytest = "*"
 flake8 = "*"
+mock = "*"
 
 [requires]
 python_version = "3.7"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -3,7 +3,7 @@ from mock import patch
 from duckpy import Client
 
 
-def test_empty_products(client):
+def test_empty_include(client):
     response = client.post('/')
 
     assert response.status_code == 400
@@ -11,7 +11,7 @@ def test_empty_products(client):
 
 @patch.object(Client, 'search')
 def test_positive_query(mock_search, client):
-    response = client.post('/?products[]=tofu')
+    response = client.post('/?include[]=tofu')
 
     assert response.status_code == 200
     mock_search.assert_called_with('tofu recipes')

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -11,7 +11,7 @@ def test_empty_include(client):
 
 @patch.object(Client, 'search')
 def test_positive_query(mock_search, client):
-    response = client.post('/?include[]=tofu')
+    response = client.post('/', query_string={'include[]': ['tofu']})
 
     assert response.status_code == 200
     mock_search.assert_called_with('tofu recipes')

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,2 +1,17 @@
-def test_request(client):
-    client.post('/')
+from mock import patch
+
+from duckpy import Client
+
+
+def test_empty_products(client):
+    response = client.post('/')
+
+    assert response.status_code == 400
+
+
+@patch.object(Client, 'search')
+def test_positive_query(mock_search, client):
+    response = client.post('/?products[]=tofu')
+
+    assert response.status_code == 200
+    mock_search.assert_called_with('tofu recipes')

--- a/web/app.py
+++ b/web/app.py
@@ -7,12 +7,12 @@ app = Flask(__name__)
 
 @app.route('/', methods=['POST'])
 def root():
-    products = request.args.getlist('products[]')
-    if not products:
+    include = request.args.getlist('include[]')
+    if not include:
         return abort(400)
 
-    products = ' '.join(products)
-    results = ddg().search(f'{products} recipes')
+    query = ' '.join(include)
+    results = ddg().search(f'{query} recipes')
     urls = [result['url'] for result in results]
 
     session = FuturesSession()


### PR DESCRIPTION
Some preparatory interface cleanup (and test coverage) before the `recrawler` service is integrated with the `api` service.