### PR TITLE
Ignore recrawling for non-zero search offsets

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -28,6 +28,14 @@ def equipment_query():
     }
 
 
+@pytest.fixture
+def offset_query():
+    return {
+        'include[]': ['tofu'],
+        'offset': 10
+    }
+
+
 def test_empty_query(client):
     response = client.post('/')
 
@@ -56,3 +64,10 @@ def test_equipment_query(mock_search, equipment_query, client):
 
     assert response.status_code == 200
     mock_search.assert_called_with('tofu -beef slow cooker recipes')
+
+
+@patch.object(Client, 'search')
+def test_offset_query(mock_search, offset_query, client):
+    response = client.post('/', query_string=offset_query)
+
+    assert response.status_code == 501

--- a/web/app.py
+++ b/web/app.py
@@ -10,12 +10,19 @@ def root():
     include = request.args.getlist('include[]')
     exclude = request.args.getlist('exclude[]')
     equipment = request.args.getlist('equipment[]')
+    offset = request.args.get('offset', type=int, default=0)
 
-    if not include:
+    # Ensure we can form a positive query
+    if not include and not equipment:
         return abort(400)
 
+    # Ignore pagination for now
+    if offset > 0:
+        return abort(501)
+
+    # Construct a web search query
     query = ' '.join(include)
-    query += ' -'.join([''] + exclude) if exclude else ''
+    query += ' -'.join([''] + exclude)
     query += ' '.join([''] + equipment)
     query += ' recipes'
 


### PR DESCRIPTION
Users can paginate through results in the application, and each of these actions performs a 'search' via the API.

Although it could be useful to paginate `recrawler` web searches in parallel with the originating request (i.e. user is viewing a second page of recipes; perform a web search and gather the second page of recipes found), currently this isn't supported.