### PR TITLE
Add Mojeek as a web search API provider

### DIFF
--- a/k8s/scripts/create-secrets.sh
+++ b/k8s/scripts/create-secrets.sh
@@ -1,0 +1,6 @@
+echo "Please provide the Mojeek API key"
+read -s mojeek_api_key
+
+kubectl delete secret recrawler-client-credentials
+kubectl create secret generic recrawler-client-credentials \
+  --from-literal=mojeek-api-key="${mojeek_api_key}"

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -21,3 +21,9 @@ spec:
         name: recrawler
         ports:
         - containerPort: 8000
+        env:
+          - name: MOJEEK_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: recrawler-client-credentials
+                key: mojeek-api-key

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -194,6 +194,9 @@ pyflakes==3.1.0 \
     --hash=sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774 \
     --hash=sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
     # via flake8
+pymojeek==0.1.1 \
+    --hash=sha256:dd0ec05c4af9fc05423f710a79aa0c043961afdcab86afc94803346420b67bac
+    # via -r requirements.txt
 pytest==7.4.0 \
     --hash=sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32 \
     --hash=sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ cachetools==5.3.1
 flask==2.3.3
 gunicorn==21.2.0
 httpx==0.24.1
+pymojeek==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,6 +112,9 @@ packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
     # via gunicorn
+pymojeek==0.1.1 \
+    --hash=sha256:dd0ec05c4af9fc05423f710a79aa0c043961afdcab86afc94803346420b67bac
+    # via -r requirements.in
 sniffio==1.3.0 \
     --hash=sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101 \
     --hash=sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,7 @@
 import pytest
+from unittest.mock import patch
+
+from pymojeek import Search
 
 
 @pytest.fixture
@@ -29,3 +32,34 @@ def test_empty_query(client):
     response = client.post("/")
 
     assert response.status_code == 400
+
+
+@patch.object(Search, "search")
+def test_positive_query(mock_search, positive_query, client):
+    response = client.post("/", query_string=positive_query)
+
+    assert response.status_code == 200
+    mock_search.assert_called_with("tofu recipes", exclude_words=[])
+
+
+@patch.object(Search, "search")
+def test_negative_query(mock_search, negative_query, client):
+    response = client.post("/", query_string=negative_query)
+
+    assert response.status_code == 200
+    mock_search.assert_called_with("tofu recipes", exclude_words=["beef"])
+
+
+@patch.object(Search, "search")
+def test_equipment_query(mock_search, equipment_query, client):
+    response = client.post("/", query_string=equipment_query)
+
+    assert response.status_code == 200
+    mock_search.assert_called_with("tofu slow cooker recipes", exclude_words=["beef"])
+
+
+@patch.object(Search, "search")
+def test_offset_query(mock_search, offset_query, client):
+    response = client.post("/", query_string=offset_query)
+
+    assert response.status_code == 501

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -50,6 +50,7 @@ def test_negative_query(mock_search, negative_query, client):
     mock_search.assert_called_with("tofu recipes", exclude_words=["beef"])
 
 
+@pytest.mark.skip("equipment validation and web search pending openculinary/backend#79")
 @patch.object(Search, "search")
 def test_equipment_query(mock_search, equipment_query, client):
     response = client.post("/", query_string=equipment_query)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Recrawling of recipes dynamically from the web based on user queries has been turned off since shortly after #8 was discovered.

Mojeek provide a [Web Search API](https://www.mojeek.co.uk/services/search/web-search-api/) that we can integrate with, and that's what this pull request does.

### Briefly summarize the changes
1. Add the `pymojeek` library as a dependency.
2. Perform recipe queries using the Mojeek Search API.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #8 indirectly, by migrating to an alternative provider.
See also: 2229817e3769ebb6c86b89ab5053c26e562bd3d5 (much of the test coverage here is from a revert of this commit)